### PR TITLE
Use bitset to make use of flags

### DIFF
--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -662,13 +662,10 @@ void ApiConnection::processRequest(Json::Value& jRequest, Json::Value& jResponse
         if (miner)
         {
             if (pause)
-            {
-                miner->set_mining_paused(MinigPauseReason::MINING_PAUSED_API);
-            }
+                miner->pause(MinerPauseEnum::PauseDueToAPIRequest);
             else
-            {
-                miner->clear_mining_paused(MinigPauseReason::MINING_PAUSED_API);
-            }
+                miner->resume(MinerPauseEnum::PauseDueToAPIRequest);
+
             jResponse["result"] = true;
         }
         else
@@ -964,10 +961,9 @@ Json::Value ApiConnection::getMinerStatDetailPerMiner(
     /* Pause infos */
     if (miner && index < p.miningIsPaused.size())
     {
-        MinigPauseReason pause_reason = miner->get_mining_paused();
-        MiningPause m;
-        jRes["ispaused"] = m.is_mining_paused(pause_reason);
-        jRes["pause_reason"] = m.get_mining_paused_string(pause_reason);
+        bool paused = miner->paused();
+        jRes["ispaused"] = paused;
+        jRes["pause_reason"] = (paused ? miner->pausedString() : Json::Value::null);
     }
     else
     {

--- a/libdevcore/Worker.h
+++ b/libdevcore/Worker.h
@@ -55,6 +55,7 @@ public:
     /// Stop worker thread; causes call to stopWorking().
     void stopWorking();
 
+    /// Whether or not this worker should stop
     bool shouldStop() const { return m_state != WorkerState::Started; }
 
 private:

--- a/libethash-cuda/CUDAMiner.cpp
+++ b/libethash-cuda/CUDAMiner.cpp
@@ -433,7 +433,7 @@ void CUDAMiner::search(
 
         // Check on every batch if we need to suspend mining
         if (!done)
-            done = is_mining_paused();
+            done = paused();
 
         // This inner loop will process each cuda stream individually
         for (current_index = 0;

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -77,14 +77,7 @@ public:
      * @brief Sets the current mining mission.
      * @param _wp The work package we wish to be mining.
      */
-    void setWork(WorkPackage const& _wp)
-    {
-        // Set work to each miner
-        Guard l(x_minerWork);
-        m_work = _wp;
-        for (auto const& m : m_miners)
-            m->setWork(m_work);
-    }
+    void setWork(WorkPackage const& _wp);
 
     void setSealers(std::map<std::string, SealerDescriptor> const& _sealers);
 
@@ -95,9 +88,24 @@ public:
 
     /**
      * @brief All mining activities to a full stop.
-     *        Implies all mining threads are stopped.
+     * Implies all mining threads are stopped.
      */
     void stop();
+
+    /**
+     * @brief Signals all miners to suspend mining
+     */
+    void pause();
+
+    /**
+     * @brief Whether or not the whole farm has been paused
+     */
+    bool paused();
+
+    /**
+     * @brief Signals all miners to resume mining
+     */
+    void resume();
 
     /**
      * @brief Stop all mining activities and Starts them again
@@ -202,6 +210,9 @@ public:
     void submitProof(Solution const& _s) override;
 
 private:
+
+    std::atomic<bool> m_paused = {false};
+
     // Collects data about hashing and hardware status
     void collectData(const boost::system::error_code& ec);
 


### PR DESCRIPTION
When pausing miners use flags as bitsets.
Some rework on methods names.
Adjusted scope for temperature threshold checking.