### PR TITLE
API: miner_getstatdetail(). Several changes.

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -198,11 +198,12 @@ and expect back a response like this:
     "epoch_changes": 1,                 // Ethminer starts with epoch 0. First connection to pool increments this counter
     "hashrate": 46709128,               // Overall HashRate in H/s
     "hostname": "<omitted-hostname>",
-    "runtime": 4,                       // Total running time in minutes
+    "runtime": 240,                     // Total running time in seconds
     "shares": {                         // Summarized info about shares
       "accepted": 5,
       "acceptedstale": 1,
       "invalid": 1,
+      "lastupdate": 58,                 // Latest update of any share info of is X seconds ago
       "rejected": 0
     },
     "tstart": 63,
@@ -221,7 +222,7 @@ and expect back a response like this:
          "accepted": 3,
          "acceptedstale": 0,
          "invalid": 0,
-         "lastupdate": 1,               // Share info from this GPU updated X minutes ago
+         "lastupdate": 58,              // Share info from this GPU updated X seconds ago
          "rejected": 0
        },
        "temp": 53                       // Temperature in °C
@@ -238,7 +239,7 @@ and expect back a response like this:
          "accepted": 2,
          "acceptedstale": 1,
          "invalid": 1,
-         "lastupdate": 2,
+         "lastupdate": 134,
          "rejected": 0
        },
        "temp": 56

--- a/libapicore/ApiServer.h
+++ b/libapicore/ApiServer.h
@@ -54,8 +54,8 @@ private:
     void onSendSocketDataCompleted(const boost::system::error_code& ec);
 
     Json::Value getMinerStatDetail();
-    Json::Value getMinerStatDetailPerMiner(
-        const WorkingProgress& p, const SolutionStats& s, size_t index);
+    Json::Value getMinerStatDetailPerMiner(const WorkingProgress& p, const SolutionStats& s,
+        size_t index, const std::chrono::steady_clock::time_point& now);
 
     Disconnected m_onDisconnected;
 

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -240,8 +240,8 @@ private:
     boost::asio::deadline_timer m_collectTimer;
     static const int m_collectInterval = 5000;
 
-    mutable SolutionStats m_solutionStats;
     std::chrono::steady_clock::time_point m_farm_launched = std::chrono::steady_clock::now();
+    mutable SolutionStats m_solutionStats;
 
     string m_pool_addresses;
 

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -125,40 +125,36 @@ public:
         if (m_accepts.size() <= miner_index)
             m_accepts.resize(miner_index + 1);
         m_accepts[miner_index]++;
-        auto now = std::chrono::steady_clock::now();
         if (m_lastUpdated.size() <= miner_index)
-            m_lastUpdated.resize(miner_index + 1, now);
-        m_lastUpdated[miner_index] = now;
+            m_lastUpdated.resize(miner_index + 1, m_tpInitalized);
+        m_lastUpdated[miner_index] = std::chrono::steady_clock::now();
     }
     void rejected(unsigned miner_index)
     {
         if (m_rejects.size() <= miner_index)
             m_rejects.resize(miner_index + 1);
         m_rejects[miner_index]++;
-        auto now = std::chrono::steady_clock::now();
         if (m_lastUpdated.size() <= miner_index)
-            m_lastUpdated.resize(miner_index + 1, now);
-        m_lastUpdated[miner_index] = now;
+            m_lastUpdated.resize(miner_index + 1, m_tpInitalized);
+        m_lastUpdated[miner_index] = std::chrono::steady_clock::now();
     }
     void failed(unsigned miner_index)
     {
         if (m_failures.size() <= miner_index)
             m_failures.resize(miner_index + 1);
         m_failures[miner_index]++;
-        auto now = std::chrono::steady_clock::now();
         if (m_lastUpdated.size() <= miner_index)
-            m_lastUpdated.resize(miner_index + 1, now);
-        m_lastUpdated[miner_index] = now;
+            m_lastUpdated.resize(miner_index + 1, m_tpInitalized);
+        m_lastUpdated[miner_index] = std::chrono::steady_clock::now();
     }
     void acceptedStale(unsigned miner_index)
     {
         if (m_acceptedStales.size() <= miner_index)
             m_acceptedStales.resize(miner_index + 1);
         m_acceptedStales[miner_index]++;
-        auto now = std::chrono::steady_clock::now();
         if (m_lastUpdated.size() <= miner_index)
-            m_lastUpdated.resize(miner_index + 1, now);
-        m_lastUpdated[miner_index] = now;
+            m_lastUpdated.resize(miner_index + 1, m_tpInitalized);
+        m_lastUpdated[miner_index] = std::chrono::steady_clock::now();
     }
 
     unsigned getAccepts() const { return accumulate(m_accepts.begin(), m_accepts.end(), 0); }
@@ -196,8 +192,16 @@ public:
     std::chrono::steady_clock::time_point getLastUpdated(unsigned miner_index) const
     {
         if (m_lastUpdated.size() <= miner_index)
-            return std::chrono::steady_clock::now();
+            return m_tpInitalized;
         return m_lastUpdated[miner_index];
+    }
+    std::chrono::steady_clock::time_point getLastUpdated() const
+    {
+        /* return the newest update time of all GPUs */
+        if (!m_lastUpdated.size())
+            return m_tpInitalized;
+        auto max_index = std::max_element(m_lastUpdated.begin(), m_lastUpdated.end());
+        return m_lastUpdated[std::distance(m_lastUpdated.begin(), max_index)];
     }
 
     std::string getString(unsigned miner_index)
@@ -223,6 +227,7 @@ private:
     std::vector<unsigned> m_failures = {};
     std::vector<unsigned> m_acceptedStales = {};
     std::vector<std::chrono::steady_clock::time_point> m_lastUpdated = {};
+    const std::chrono::steady_clock::time_point m_tpInitalized = std::chrono::steady_clock::now();
 };
 
 std::ostream& operator<<(std::ostream& os, const SolutionStats& s);


### PR DESCRIPTION
Change all time information to seconds.
Add 'lastupdate' to global miner share info in response.
Set 'lastupdate' timestamps initially to time when farm got launched.