### PR TITLE
Faster exit with CUDA devices.

### DIFF
--- a/libdevcore/Worker.cpp
+++ b/libdevcore/Worker.cpp
@@ -83,6 +83,16 @@ void Worker::startWorking()
         this_thread::sleep_for(chrono::microseconds(20));
 }
 
+void Worker::triggerStopWorking()
+{
+    DEV_GUARDED(x_work)
+    if (m_work)
+    {
+        WorkerState ex = WorkerState::Started;
+        m_state.compare_exchange_strong(ex, WorkerState::Stopping);
+    }
+}
+
 void Worker::stopWorking()
 {
     DEV_GUARDED(x_work)

--- a/libdevcore/Worker.h
+++ b/libdevcore/Worker.h
@@ -55,7 +55,10 @@ public:
     /// Starts worker thread; causes startedWorking() to be called.
     void startWorking();
 
-    /// Stop worker thread; causes call to stopWorking().
+    /// Triggers worker thread it should stop
+    void triggerStopWorking();
+
+    /// Stop worker thread; causes call to stopWorking() and waits till thread has stopped.
     void stopWorking();
 
     /// Whether or not this worker should stop

--- a/libethcore/Farm.cpp
+++ b/libethcore/Farm.cpp
@@ -151,6 +151,8 @@ void Farm::stop()
     {
         {
             Guard l(x_minerWork);
+            for (auto const& miner : m_miners)
+                miner->triggerStopWorking();
             m_miners.clear();
             m_isMining.store(false, std::memory_order_relaxed);
         }


### PR DESCRIPTION
A call to cudaDeviceReset() needs in my environment between 1 and 5 seconds.
When stopping ethminer, Farm::stop() clears the m_miners list.
This involves that **sequential** the destructor of each m_miner element is called.
As the destructor of CUDAMiner implicit calls cudaDeviceReset() and waits till
mining of the thread has stopped that way can cause exiting needs
up to 5 seconds per card.

With this patch the mining threads gets async informed to stop
which results in a faster total exit time.