### PR TITLE
Allow passing "." as username or workername using %2e.

### DIFF
--- a/libpoolprotocols/PoolURI.cpp
+++ b/libpoolprotocols/PoolURI.cpp
@@ -156,7 +156,29 @@ URI::URI(const std::string uri)
             tmpstr++;
         len = tmpstr - curstr;
         m_username.append(curstr, len);
+
+#if 0
         m_username = urlDecode(m_username);
+#else
+        // Expect we got a uri "username%2e246891.rigname%2e01:x@eu-01.miningrigrentals.com:3344"
+        // which should mean: username = "username.246891"
+        //                    workername = "rigname.01"
+        // we must split username and workername before urlDecode() is called !
+
+        auto p = m_username.find_first_of(".");
+        if (p != std::string::npos)
+        {
+            m_username = m_username.substr(0, p);
+
+            // There should be at least one char after dot
+            // returned p is zero based
+            if (p < (m_username.length() - 1))
+                m_workername = m_username.substr(++p);
+        }
+        m_username = urlDecode(m_username);
+        m_workername = urlDecode(m_workername);
+#endif
+
         // Look for password
         curstr = tmpstr;
         if (':' == *curstr)

--- a/libpoolprotocols/PoolURI.h
+++ b/libpoolprotocols/PoolURI.h
@@ -59,6 +59,7 @@ public:
     unsigned short Port() const { return m_port; }
     std::string User() const { return m_username; }
     std::string Pass() const { return m_password; }
+    std::string Workername() const { return m_workername; }
     SecureLevel SecLevel() const;
     ProtocolFamily Family() const;
     UriHostNameType HostNameType() const;
@@ -89,6 +90,7 @@ private:
     std::string m_query;
     std::string m_fragment;
     std::string m_username;
+    std::string m_workername;
     std::string m_password;
     std::string m_uri;
     unsigned short m_stratumMode = 999;  // Initial value 999 means not tested yet

--- a/libpoolprotocols/stratum/EthStratumClient.cpp
+++ b/libpoolprotocols/stratum/EthStratumClient.cpp
@@ -662,23 +662,9 @@ void EthStratumClient::connect_handler(const boost::system::error_code& ec)
     m_sendBuffer.consume(4096);
     clear_response_pleas();
 
-    // Extract user and worker
-    size_t p;
-    m_worker.clear();
-    p = m_conn->User().find_first_of(".");
-    if (p != string::npos)
-    {
-        m_user = m_conn->User().substr(0, p);
-
-        // There should be at least one char after dot
-        // returned p is zero based
-        if (p < (m_conn->User().length() - 1))
-            m_worker = m_conn->User().substr(++p);
-    }
-    else
-    {
-        m_user = m_conn->User();
-    }
+    // User and worker
+    m_user = m_conn->User();
+    m_worker = m_conn->Workername();
 
     /*
 


### PR DESCRIPTION
As we split username and workername by "." we have to do it before
an urlDecode() is called as otherwise it is not clear which part is
username and which is workername.

Previous this commit:
-P username%2e246891.rigname%2e01:x@HOST:PORT
        Username = username, Workername = 246891.rigname.01
-P username%2erigname:x@HOST:PORT
        Username = username, Workername = rigname

With this commit
-P username%2e246891.rigname%2e01:x@HOST:PORT
        Username = username.246891, Workername = rigname.01
-P username%2erigname:x@HOST:PORT
        Username = username.rigname, Workername =

So this commit breaks a syntax of
	username%2erigname:x@HOST:PORT

as now this results in a
	Username = username.rigname
against previous
	Username = username, Workername = rigname

This commit should fix
	https://github.com/ethereum-mining/ethminer/issues/1687
	https://github.com/ethereum-mining/ethminer/issues/1075