### PR TITLE
Avoid build warning.

### DIFF
--- a/libdevcore/CommonData.cpp
+++ b/libdevcore/CommonData.cpp
@@ -156,10 +156,10 @@ double dev::getHashesToTarget(string _target)
 }
 
 std::string dev::getScaledSize(double _value, double _divisor, short _precision, string _sizes[],
-    int _numsizes, ScaleSuffix _suffix)
+    size_t _numsizes, ScaleSuffix _suffix)
 {
     double _newvalue = _value;
-    unsigned i = 0;
+    size_t i = 0;
     while (true)
     {
         if (_newvalue < _divisor || i == (_numsizes - 1))

--- a/libdevcore/CommonData.h
+++ b/libdevcore/CommonData.h
@@ -213,7 +213,7 @@ double getHashesToTarget(std::string _target);
 
 /// Generic function to scale a value
 std::string getScaledSize(double _value, double _divisor, short _precision, std::string _sizes[],
-    int _numsizes, ScaleSuffix _suffix = ScaleSuffix::Add);
+    size_t _numsizes, ScaleSuffix _suffix = ScaleSuffix::Add);
 
 /// Formats hashrate
 std::string getFormattedHashes(double _hr, ScaleSuffix _suffix = ScaleSuffix::Add);


### PR DESCRIPTION
Avoid following build warning:
warning: comparison between signed and unsigned integer expressions