### PR TITLE
Allow setting startnonce and noncesegmentwidth via CLI.

### DIFF
--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -248,6 +248,12 @@ public:
         app.add_option("--ergodicity", m_FarmSettings.ergodicity, "", true)
             ->check(CLI::Range(0, 2));
 
+        app.add_option("--startnonce", m_FarmSettings.startNonce, "", true)
+            ->check(CLI::Range(1ull, 18446744073709551615ull));
+
+        app.add_option("--noncesegmentwidth", m_FarmSettings.nonceSegmentWidth, "", true)
+            ->check(CLI::Range(10, 50));
+
         bool version = false;
 
         app.add_flag("-V,--version", version, "Show program version");
@@ -513,6 +519,15 @@ public:
                 std::string what = "-tstop must be greater than -tstart";
                 throw std::invalid_argument(what);
             }
+        }
+
+        if (m_FarmSettings.ergodicity != 0 && m_FarmSettings.startNonce)
+        {
+            // If we got a --startnonce and
+            // change nonce every job/session:
+            //      generate an error
+            std::string what = "You can not mix --ergodicity and --startnonce";
+            throw std::invalid_argument(what);
         }
 
         // Output warnings if any
@@ -1037,6 +1052,10 @@ public:
                  << "                        0 A search segment is picked at startup" << endl
                  << "                        1 A search segment is picked on every pool connection" << endl
                  << "                        2 A search segment is picked on every new job" << endl
+                 << "    --startnonce        UINT[1 .. 184467440737095516162] Default: not set" << endl
+                 << "                        Set the nonce to an explicit value." << endl
+                 << "                        This is only useful if you benchmark!" << endl
+                 << "    --noncesegmentwidth INT [10 .. 50] Default = 32" << endl
                  << endl
                  << "    --nocolor           FLAG Monochrome display log lines" << endl
                  << "    --syslog            FLAG Use syslog appropriate output (drop timestamp and" << endl

--- a/libethcore/Farm.cpp
+++ b/libethcore/Farm.cpp
@@ -146,8 +146,12 @@ Farm::Farm(std::map<std::string, DeviceDescriptor>& _DevicesCollection, FarmSett
         }
     }
 
-    // Initialize nonce_scrambler
-    shuffle();
+    // Initialize nonce and nonce range
+    m_nonce_segment_with = m_Settings.nonceSegmentWidth;
+    if (m_Settings.startNonce)
+        m_nonce_scrambler = m_Settings.startNonce;
+    else
+        shuffle();
 
     // Start data collector timer
     // It should work for the whole lifetime of Farm

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -50,12 +50,14 @@ namespace eth
 {
 struct FarmSettings
 {
-    unsigned dagLoadMode = 0;  // 0 = Parallel; 1 = Serialized
-    bool noEval = false;       // Whether or not to re-evaluate solutions
-    unsigned hwMon = 0;        // 0 - No monitor; 1 - Temp and Fan; 2 - Temp Fan Power
-    unsigned ergodicity = 0;   // 0=default, 1=per session, 2=per job
-    unsigned tempStart = 40;   // Temperature threshold to restart mining (if paused)
-    unsigned tempStop = 0;     // Temperature threshold to pause mining (overheating)
+    unsigned dagLoadMode = 0;         // 0 = Parallel; 1 = Serialized
+    bool noEval = false;              // Whether or not to re-evaluate solutions
+    unsigned hwMon = 0;               // 0 - No monitor; 1 - Temp and Fan; 2 - Temp Fan Power
+    unsigned ergodicity = 0;          // 0=default, 1=per session, 2=per job
+    uint64_t startNonce = 0;          // 0=not set, each other value: use it as nonce
+    unsigned nonceSegmentWidth = 32;  //
+    unsigned tempStart = 40;          // Temperature threshold to restart mining (if paused)
+    unsigned tempStop = 0;            // Temperature threshold to pause mining (overheating)
 };
 
 /**
@@ -288,8 +290,8 @@ private:
     // considering an average block time of 15 seconds
     // a single device GPU should need a speed of 286 Mh/s
     // before it consumes the whole 2^32 segment
-    uint64_t m_nonce_scrambler;
-    unsigned int m_nonce_segment_with = 32;
+    uint64_t m_nonce_scrambler;         // see also: FarmSettings.startNonce
+    unsigned int m_nonce_segment_with;  // set from FarmSettings.nonceSegmentWidth
 
     // Wrappers for hardware monitoring libraries and their mappers
     wrap_nvml_handle* nvmlh = nullptr;


### PR DESCRIPTION
Those options were useful when searching invalid generated solutions.
It also allows generating more deterministic benchmarks as you can use
the same nonce in benchmark mode.

Maybe we should add them under `#ifdef _DEVELOPER` ?
