### PR TITLE
Fix fast exit

### DIFF
--- a/libethash-cl/CLMiner.cpp
+++ b/libethash-cl/CLMiner.cpp
@@ -703,7 +703,7 @@ void CLMiner::kick_miner()
     Miner::kick_miner();
     if (m_activeKernel.load(memory_order_relaxed))
         m_queue_abort.enqueueWriteBuffer(
-            m_searchBuffer, CL_FALSE, offsetof(search_results, abort), sizeof(m_one), &m_one);
+            m_searchBuffer, CL_TRUE, offsetof(search_results, abort), sizeof(m_one), &m_one);
 }
 
 bool CLMiner::initDevice()

--- a/libethash-cl/progpow_miner_kernel.cl
+++ b/libethash-cl/progpow_miner_kernel.cl
@@ -182,7 +182,7 @@ typedef struct
 __attribute__((reqd_work_group_size(GROUP_SIZE, 1, 1)))
 #endif
 __kernel void progpow_search(
-    __global search_results* restrict g_output,
+    __global volatile search_results* restrict g_output,
     __constant hash32_t const* g_header,
     __global ulong8 const* _g_dag,
     ulong start_nonce,


### PR DESCRIPTION
- An asynch kick should be enough, but on AMD it's not!
  Use synchronous enqWrite to trigger kernel exit.